### PR TITLE
Removed gen_users.sql

### DIFF
--- a/internal/database/queries/gen_users.sql
+++ b/internal/database/queries/gen_users.sql
@@ -1,6 +1,0 @@
--- TODO(@seoyoungcho213) : modify this based on AddUser()
-INSERT INTO users (username, email, password)
-VALUES ('Ancient One', 'ancientone@gmail.com', 'pw1'),
-       ('Alice', 'alice@example.com', 'pw2'),
-       ('Bob', 'bob@example.com', 'pw3'),
-       ('Charlie', 'charlie@example.com', 'pw4');


### PR DESCRIPTION
## Rationale
I decided to remove gen_users.sql since we already have unit-test, and gen_users.sql doesn't work anymore because of password hashing -- it doesn't authenticate anymore.

## Usage
If we want to add users when you start the server, use 'sign up' page.

## Changes
deleted gen_users.sql

### Testing

- [ ] ➕ Added units to existing tests
- [ ] 🐣 Started a new group of tests
- [x] 🙅 New tests aren't needed
- [ ] 🙋 Need help to add tests

### Dependencies
N/A

### Documentation Changes

- [ ] 📜 README.md
- [ ] 💬 Added **necessary** comments to existing code
- [x] 🙅 no documentation needed

## Issues and Bugs
N/A

## Possible Solutions
N/A

## Additional Notes
It might be useful to add users without AddUsers() function.
