### PR TITLE
os-based-fsevents-dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ Please make sure to update tests as appropriate.
 4. To import dependencies, **run**: ```go mod tidy```.
 5. To run tests, **run**: ```go test ./...```.
 
+### CSS (Tailwind) contributing
+
+1. Run `npm install`
+2. After modifying tailwind files (e.g. tailwind.config.js), run `npm run build-css`
+
+If the Mac-only dependency of tailwind (fsevents) silently fails (unlikely), you will get an error
+like `fsevents.watch is not a function`
+
+Then run `npm install fsevents --no-save` and proceed based on NPM's error output. 
 ## Dependencies
 
 * Development environments optimized for **GoLand**

--- a/package.json
+++ b/package.json
@@ -9,13 +9,6 @@
     "tailwindcss": "^3.4.4"
   },
   "optionalDependencies": {
-    "fsevents": "^2.3.2"
-  },
-  "overrides": {
-    "fsevents": {
-      "os": [
-        "darwin"
-      ]
-    }
+    "fsevents": "^2.3.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,10 +3,19 @@
     "build-css": "npx tailwindcss -o public/stylesheets/styles.css --watch --minify"
   },
   "dependencies": {
-    "fsevents": "^2.3.3",
     "live-server": "^1.2.0"
   },
   "devDependencies": {
     "tailwindcss": "^3.4.4"
+  },
+  "optionalDependencies": {
+    "fsevents": "^2.3.2"
+  },
+  "overrides": {
+    "fsevents": {
+      "os": [
+        "darwin"
+      ]
+    }
   }
 }


### PR DESCRIPTION
## Rationale

tailwindcss throws error messages on Mac (darwin) if "fsevents" not present, have to manual install it. but fsevents fails on non-Mac. avoid unsynced package.json by making it optional for non-Macs, hopefully this makes it install on Macs. Also, making things work off `npm install` without needing to do manual, no-save installs is nice.

## Usage

just run `npm install` (regardless of OS), do *not* need to manually `npm -D install tailwindcss`

## Changes

### Non-trivial Files

package.json

### Testing

- [ ] ➕ Added units to existing tests
- [ ] 🐣 Started a new group of tests
- [ ] 🙅 New tests aren't needed
- [X] 🙋 Need help to add tests

On my Linux device, this silently skips fsevents:
```
faaiz@pop-os:~/GolandProjects/matcha$ npm list 
matcha@ /home/faaiz/GolandProjects/matcha
├── UNMET OPTIONAL DEPENDENCY fsevents@^2.3.2
├── live-server@1.2.2
└── tailwindcss@3.4.5
```

```
faaiz@pop-os:~/GolandProjects/matcha$ node
Welcome to Node.js v20.6.1.
Type ".help" for more information.
> const fs = require('fsevents')
Uncaught Error: Cannot find module 'fsevents'
Require stack:
- <repl>
    at Module._resolveFilename (node:internal/modules/cjs/loader:1048:15)
    at Module._load (node:internal/modules/cjs/loader:901:27)
    at Module.require (node:internal/modules/cjs/loader:1115:19)
    at require (node:internal/modules/helpers:130:18) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [ '<repl>' ]
}
```

We absolutely need a Mac to re-run `npm install` and test these commands do install fsevents.

### Dependencies

fsevents made optional per OS 

### Documentation Changes

- [X] 📜 README.md
- [ ] 💬 Added **necessary** comments to existing code
- [ ] 🙅 no documentation needed

## Issues and Bugs

If legitimate error occurs installing fsevents on mac, this may fail silently. "overrides" also might have unknown consequences

## Possible Solutions

Hopefully, the tailwindcss error messages make it obvious if fsevents failed to install, at which point you can run:

```npm install fsevents@^2.3.2 --no-save```

## Additional Notes

As far as I know, there's no generally accepted npm method to accomplish this. Running install scripts from package.json is [considered an anti-pattern](https://web.archive.org/web/20150319143342/https://docs.npmjs.com/misc/scripts#note-install-scripts-are-an-antipattern); there is a package to do this `run-script-os`, but we'd be pulling in a new dependency around selective install of a single dep. 